### PR TITLE
feat: `Lasso.expect_once`

### DIFF
--- a/lib/lasso.ex
+++ b/lib/lasso.ex
@@ -39,6 +39,18 @@ defmodule Lasso do
     end
   end
 
+  def expect_once(lasso, method, path, responder) do
+    expectation = %__MODULE__.Expectation{
+      method: method,
+      path: path,
+      responder: responder,
+      request_count: 0,
+      expected_request_count: 1
+    }
+
+    GenServer.call(lasso.pid, {:expect, expectation})
+  end
+
   def expect(lasso, method, path, responder) do
     expectation = %__MODULE__.Expectation{
       method: method,


### PR DESCRIPTION
Hi :wave: 

Thanks for taking the time to write a mocking server on top of `bandit`.

Having a way to expect a specific amount eases the migration from `bypass` to `lasso` for me.

Maybe better to have a more general approach and have the expected count as an argument to `expect` instead?